### PR TITLE
Added TokenTransferDelegate to avoid ERC20 re-authorization

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -25,6 +25,7 @@ import "./lib/UintLib.sol";
 import "./LoopringProtocol.sol";
 import "./RinghashRegistry.sol";
 import "./TokenRegistry.sol";
+import "./TokenTransferDelegate.sol";
 
 /// @title Loopring Token Exchange Protocol Implementation Contract v1
 /// @author Daniel Wang - <daniel@loopring.org>,
@@ -42,6 +43,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
     address public  lrcTokenAddress             = address(0);
     address public  tokenRegistryAddress        = address(0);
     address public  ringhashRegistryAddress     = address(0);
+    address public  delegateAddress             = address(0);
+
     uint    public  maxRingSize                 = 0;
     uint    public  ringIndex                   = 0;
     uint    public  maxPriceRateDeviation       = 0;
@@ -128,6 +131,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         address _lrcTokenAddress,
         address _tokenRegistryAddress,
         address _ringhashRegistryAddress,
+        address _delegateAddress,
         uint    _maxRingSize,
         uint    _maxPriceRateDeviation
         )
@@ -135,12 +139,15 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
         require(address(0) != _lrcTokenAddress);
         require(address(0) != _tokenRegistryAddress);
+        require(address(0) != _delegateAddress);
+
         require(_maxRingSize >= 2);
         require(_maxPriceRateDeviation >= 1);
 
         lrcTokenAddress             = _lrcTokenAddress;
         tokenRegistryAddress        = _tokenRegistryAddress;
         ringhashRegistryAddress     = _ringhashRegistryAddress;
+        delegateAddress             = _delegateAddress;
         maxRingSize                 = _maxRingSize;
         maxPriceRateDeviation       = _maxPriceRateDeviation;
     }
@@ -379,6 +386,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
     function settleRing(Ring ring) internal {
         uint ringSize = ring.orders.length;
+        var delegate = TokenTransferDelegate(delegateAddress);
+
         for (uint i = 0; i < ringSize; i++) {
             var state = ring.orders[i];
             var prev = ring.orders[i.prev(ringSize)];
@@ -386,30 +395,33 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
             // Pay tokenS to previous order, or to miner as previous order's
             // saving share or/and this order's saving share.
-            var tokenS = ERC20(state.order.tokenS);
-            tokenS.transferFrom(
+
+            delegate.transferToken(
+                state.order.tokenS,
                 state.owner,
                 prev.owner,
                 state.fillAmountS - prev.savingB);
 
             if (prev.savingB + state.savingS > 0) {
-                tokenS.transferFrom(
+                delegate.transferToken(
+                    state.order.tokenS,
                     state.owner,
                     ring.feeRecepient,
                     prev.savingB + state.savingS);
             }
 
             // Pay LRC
-            var lrc = ERC20(lrcTokenAddress);
             if (state.lrcReward > 0) {
-                lrc.transferFrom(
+                delegate.transferToken(
+                    lrcTokenAddress,
                     ring.feeRecepient,
                     state.owner,
                     state.lrcReward);
             }
 
             if (state.lrcFee > 0) {
-                lrc.transferFrom(
+                 delegate.transferToken(
+                    lrcTokenAddress,
                     state.owner,
                     ring.feeRecepient,
                     state.lrcFee);

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -650,10 +650,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
         constant
         returns (uint) {
 
-        var token = ERC20(tokenAddress);
-        return token
-            .allowance(tokenOwner, address(this))
-            .min256(token.balanceOf(tokenOwner));
+        return TokenTransferDelegate(delegateAddress)
+            .getSpendable(tokenAddress, tokenOwner);
     }
 
     /// @return Amount of LRC token that can be spent by this contract.

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -1,0 +1,130 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+pragma solidity ^0.4.11;
+
+import "zeppelin-solidity/contracts/token/ERC20.sol";
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+
+/// @title TokenTransferDelegate - Acts as a middle man to transfer ERC20 tokens
+/// on behalf of different versioned of Loopring protocol to avoid ERC20
+/// re-authorization.
+/// @author Daniel Wang - <daniel@loopring.org>.
+contract TokenTransferDelegate is Ownable {
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// Variables                                                            ///
+    ////////////////////////////////////////////////////////////////////////////
+    
+    uint lastSequenceId = 0;
+    address[] public versions;
+    mapping (address => uint) public versioned;
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// Modifiers                                                            ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    modifier isVersioned(address addr) {
+        if (versioned[addr] == 0) {
+            revert();
+        }
+        _;
+    }
+
+    modifier notVersioned(address addr) {
+        if (versioned[addr] > 0) {
+            revert();
+        }
+        _;
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// Events                                                               ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    event VersionAdded(
+        address indexed addr,
+        uint sequenceId);
+
+    event VersionRemoved(
+        address indexed addr, 
+        uint sequenceId);
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// Public Functions                                                     ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @dev Add a Loopring protocol address.
+    /// @param addr A loopring protocol address.
+    function addVersion(address addr)
+        onlyOwner
+        notVersioned(addr)
+        {
+        versioned[addr] = ++lastSequenceId;
+        versions.push(addr);
+        VersionAdded(addr, lastSequenceId);
+    }
+
+    /// @dev Remove a Loopring protocol address.
+    /// @param addr A loopring protocol address.
+    function removeVersion(address addr)
+        onlyOwner
+        isVersioned(addr)
+        {
+        uint sequenceId = versioned[addr];
+        delete versioned[addr];
+
+        uint length = versions.length;
+        for (uint i = 0; i < length; i++) {
+            if (versions[i] == addr) {
+                versions[i] = versions[length - 1];
+                versions.length -= 1;
+                break;
+            }
+        }
+        VersionRemoved(addr, sequenceId);
+    }
+
+    /// @dev Invoke ERC20 transferFrom method.
+    /// @param token Address of token to transfer.
+    /// @param from Address to transfer token from.
+    /// @param to Address to transfer token to.
+    /// @param value Amount of token to transfer.
+    /// @return Tansfer result.
+    function transferToken(
+        address token,
+        address from,
+        address to,
+        uint value)
+        isVersioned(msg.sender)
+        returns (bool)
+        {
+        return ERC20(token).transferFrom(from, to, value);
+    }
+
+    /// @dev Gets all versioned addresses.
+    /// @return Array of versioned addresses.
+    function getVersions()
+        constant
+        returns (address[])
+        {
+        return versions;
+    }
+}

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -17,6 +17,7 @@
 */
 pragma solidity ^0.4.11;
 
+import "zeppelin-solidity/contracts/math/Math.sol";
 import "zeppelin-solidity/contracts/token/ERC20.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
@@ -25,6 +26,7 @@ import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 /// re-authorization.
 /// @author Daniel Wang - <daniel@loopring.org>.
 contract TokenTransferDelegate is Ownable {
+    using Math for uint;
 
     ////////////////////////////////////////////////////////////////////////////
     /// Variables                                                            ///
@@ -98,6 +100,25 @@ contract TokenTransferDelegate is Ownable {
         VersionRemoved(addr, version);
     }
 
+
+    /// @return Amount of ERC20 token that can be spent by this contract.
+    /// @param tokenAddress Address of token to transfer.
+    /// @param owner Address of the token owner.
+    function getSpendable(
+        address tokenAddress,
+        address owner
+        )
+        isVersioned(msg.sender)
+        constant
+        returns (uint) {
+
+        var token = ERC20(tokenAddress);
+        return token
+            .allowance(owner, address(this))
+            .min256(token.balanceOf(owner));
+    }
+
+
     /// @dev Invoke ERC20 transferFrom method.
     /// @param token Address of token to transfer.
     /// @param from Address to transfer token from.
@@ -110,8 +131,7 @@ contract TokenTransferDelegate is Ownable {
         address to,
         uint value)
         isVersioned(msg.sender)
-        returns (bool)
-        {
+        returns (bool) {
         return ERC20(token).transferFrom(from, to, value);
     }
 
@@ -119,8 +139,7 @@ contract TokenTransferDelegate is Ownable {
     /// @return Array of versioned addresses.
     function getVersions()
         constant
-        returns (address[])
-        {
+        returns (address[]) {
         return versions;
     }
 }

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -30,7 +30,7 @@ contract TokenTransferDelegate is Ownable {
     /// Variables                                                            ///
     ////////////////////////////////////////////////////////////////////////////
     
-    uint lastSequenceId = 0;
+    uint lastVersion = 0;
     address[] public versions;
     mapping (address => uint) public versioned;
 
@@ -58,13 +58,9 @@ contract TokenTransferDelegate is Ownable {
     /// Events                                                               ///
     ////////////////////////////////////////////////////////////////////////////
 
-    event VersionAdded(
-        address indexed addr,
-        uint sequenceId);
+    event VersionAdded(address indexed addr, uint version);
 
-    event VersionRemoved(
-        address indexed addr, 
-        uint sequenceId);
+    event VersionRemoved(address indexed addr, uint version);
 
 
     ////////////////////////////////////////////////////////////////////////////
@@ -77,9 +73,9 @@ contract TokenTransferDelegate is Ownable {
         onlyOwner
         notVersioned(addr)
         {
-        versioned[addr] = ++lastSequenceId;
+        versioned[addr] = ++lastVersion;
         versions.push(addr);
-        VersionAdded(addr, lastSequenceId);
+        VersionAdded(addr, lastVersion);
     }
 
     /// @dev Remove a Loopring protocol address.
@@ -88,7 +84,7 @@ contract TokenTransferDelegate is Ownable {
         onlyOwner
         isVersioned(addr)
         {
-        uint sequenceId = versioned[addr];
+        uint version = versioned[addr];
         delete versioned[addr];
 
         uint length = versions.length;
@@ -99,7 +95,7 @@ contract TokenTransferDelegate is Ownable {
                 break;
             }
         }
-        VersionRemoved(addr, sequenceId);
+        VersionRemoved(addr, version);
     }
 
     /// @dev Invoke ERC20 transferFrom method.


### PR DESCRIPTION
避免每次协议升级后，所有之前的ERC20授权都变得无效。引入TokenTransferDelegate后，只需要对TokenTransferDelegate进行授权即可。

Avoid ERC20 re-authorization of allowance after each protocol update, now authorising TokenTransferDelegate is sufficient.