### PR TITLE
Replace order expiration with ttl

### DIFF
--- a/contracts/LoopringProtocol.sol
+++ b/contracts/LoopringProtocol.sol
@@ -26,10 +26,10 @@ contract LoopringProtocol {
     /// Constants                                                            ///
     ////////////////////////////////////////////////////////////////////////////
     uint    public constant FEE_SELECT_LRC               = 0;
-    uint    public constant FEE_SELECT_SAVING_SHARE      = 1;
+    uint    public constant FEE_SELECT_MARGIN_SPLIT      = 1;
     uint    public constant FEE_SELECT_MAX_VALUE         = 1;
     
-    uint    public constant SAVING_SHARE_PERCENTAGE_BASE = 10000;
+    uint    public constant MARGIN_SPLIT_PERCENTAGE_BASE = 10000;
 
 
     ////////////////////////////////////////////////////////////////////////////
@@ -41,15 +41,16 @@ contract LoopringProtocol {
     /// @param amountS      Maximum amount of tokenS to sell.
     /// @param amountB      Minimum amount of tokenB to buy if all amountS sold.
     /// @param timestamp    Indicating whtn this order is created/signed.
-    /// @param expiration   Indicating when this order will expire.
+    /// @param ttl          Indicating after how many seconds from `timestamp`
+    ///                     this order will expire.
     /// @param salt         A random number to make this order's hash unique.
     /// @param lrcFee       Max amount of LRC to pay for miner. The real amount
     ///                     to pay is proportional to fill amount.
     /// @param buyNoMoreThanAmountB -
     ///                     If true, this order does not accept buying more
     ///                     than `amountB`.
-    /// @param savingSharePercentage -
-    ///                     The percentage of savings paid to miner.
+    /// @param marginSplitPercentage -
+    ///                     The percentage of margin paid to miner.
     /// @param v            ECDSA signature parameter v.
     /// @param r            ECDSA signature parameters r.
     /// @param s            ECDSA signature parameters s.
@@ -59,11 +60,11 @@ contract LoopringProtocol {
         uint    amountS;
         uint    amountB;
         uint    timestamp;
-        uint    expiration;
+        uint    ttl;
         uint    salt;
         uint    lrcFee;
         bool    buyNoMoreThanAmountB;
-        uint8   savingSharePercentage;
+        uint8   marginSplitPercentage;
         uint8   v;
         bytes32 r;
         bytes32 s;
@@ -78,11 +79,11 @@ contract LoopringProtocol {
     /// @param tokenSList   List of each order's tokenS. Note that next order's
     ///                     `tokenS` equals this order's `tokenB`.
     /// @param uintArgsList List of uint-type arguments in this order:
-    ///                     amountS, AmountB, rateAmountS, timestamp, expiration,
-    ///                     salt, and lrcFee.
+    ///                     amountS, AmountB, rateAmountS, timestamp, ttl, salt,
+    ///                     and lrcFee.
     /// @param uint8ArgsList -
     ///                     List of unit8-type arguments, in this order:
-    ///                     savingSharePercentageList, feeSelectionList.
+    ///                     marginSplitPercentageList, feeSelectionList.
     /// @param vList        List of v for each order. This list is 1-larger than
     ///                     the previous lists, with the last element being the
     ///                     v value of the ring signature.
@@ -117,9 +118,9 @@ contract LoopringProtocol {
     /// @dev Cancel a order. cancel amount(amountS or amountB) can be specified
     ///      in orderValues.
     /// @param tokenAddresses     tokenS,tokenB
-    /// @param orderValues        amountS, amountB, timestamp, expiration, salt,
-    ///                           lrcFee, cancelAmountS, and cancelAmountB.
-    /// @param savingSharePercentage -
+    /// @param orderValues        amountS, amountB, timestamp, ttl, salt, lrcFee,
+    ///                           cancelAmountS, and cancelAmountB.
+    /// @param marginSplitPercentage -
     /// @param buyNoMoreThanAmountB -
     /// @param v                  Order ECDSA signature parameter v.
     /// @param r                  Order ECDSA signature parameters r.
@@ -128,7 +129,7 @@ contract LoopringProtocol {
         address[2] tokenAddresses,
         uint[7]    orderValues,
         bool       buyNoMoreThanAmountB,
-        uint8      savingSharePercentage,
+        uint8      marginSplitPercentage,
         uint8      v,
         bytes32    r,
         bytes32    s

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -78,7 +78,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
     /// @param owner        This order owner's address. This value is calculated.
     /// @param feeSelection -
     ///                     A miner-supplied value indicating if LRC (value = 0)
-    ///                     or saving share is choosen by the miner (value = 1).
+    ///                     or margin split is choosen by the miner (value = 1).
     ///                     We may support more fee model in the future.
     /// @param fillAmountS  Amount of tokenS to sell, calculated by protocol.
     /// @param rateAmountS  This value is initially provided by miner and is
@@ -88,10 +88,10 @@ contract LoopringProtocolImpl is LoopringProtocol {
     ///                     This value and `rateAmountB` can be used to calculate
     ///                     the proposed exchange rate calculated by miner.
     /// @param lrcReward    The amount of LRC paid by miner to order owner in
-    ///                     exchange for sharing-share.
+    ///                     exchange for margin split.
     /// @param lrcFee       The amount of LR paid by order owner to miner.
-    /// @param savingS      TokenS paid to miner.
-    /// @param savingB      TokenB paid to miner.
+    /// @param marginS      TokenS paid to miner.
+    /// @param marginB      TokenB paid to miner.
     struct OrderState {
         Order   order;
         bytes32 orderHash;
@@ -102,8 +102,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
         uint    fillAmountS;
         uint    lrcReward;
         uint    lrcFee;
-        uint    savingS;
-        uint    savingB;
+        uint    marginS;
+        uint    marginB;
     }
 
     struct Ring {
@@ -197,11 +197,11 @@ contract LoopringProtocolImpl is LoopringProtocol {
     /// @param tokenSList   List of each order's tokenS. Note that next order's
     ///                     `tokenS` equals this order's `tokenB`.
     /// @param uintArgsList List of uint-type arguments in this order:
-    ///                     amountS,AmountB,timestamp,expiration,salt,lrcFee,
+    ///                     amountS, amountB, timestamp, ttl, salt, lrcFee,
     ///                     rateAmountS.
     /// @param uint8ArgsList -
     ///                     List of unit8-type arguments, in this order:
-    ///                     savingSharePercentageList,feeSelectionList.
+    ///                     marginSplitPercentageList,feeSelectionList.
     /// @param vList        List of v for each order. This list is 1-larger than
     ///                     the previous lists, with the last element being the
     ///                     v value of the ring signature.
@@ -288,19 +288,25 @@ contract LoopringProtocolImpl is LoopringProtocol {
             feeRecepient = minerAddress;
         }
 
-        handleRing(ringhash, orders, minerAddress, feeRecepient, throwIfLRCIsInsuffcient);
+        handleRing(
+            ringhash, 
+            orders,
+            minerAddress, 
+            feeRecepient, 
+            throwIfLRCIsInsuffcient
+        );
     }
 
     /// @dev Cancel a order. Amount (amountS or amountB) to cancel can be
     ///                           specified using orderValues.
     /// @param tokenAddresses     tokenS,tokenB
-    /// @param orderValues        amountS, amountB, timestamp, expiration, salt,
+    /// @param orderValues        amountS, amountB, timestamp, ttl, salt,
     ///                           lrcFee, and cancelAmount
     /// @param buyNoMoreThanAmountB -
     ///                           If true, this order does not accept buying
     ///                           more than `amountB`.
-    /// @param savingSharePercentage -
-    ///                           The percentage of savings paid to miner.
+    /// @param marginSplitPercentage -
+    ///                           The percentage of margin paid to miner.
     /// @param v                  Order ECDSA signature parameter v.
     /// @param r                  Order ECDSA signature parameters r.
     /// @param s                  Order ECDSA signature parameters s.
@@ -308,7 +314,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         address[2] tokenAddresses,
         uint[7]    orderValues,
         bool       buyNoMoreThanAmountB,
-        uint8      savingSharePercentage,
+        uint8      marginSplitPercentage,
         uint8      v,
         bytes32    r,
         bytes32    s
@@ -328,7 +334,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             orderValues[4],
             orderValues[5],
             buyNoMoreThanAmountB,
-            savingSharePercentage,
+            marginSplitPercentage,
             v,
             r,
             s
@@ -356,6 +362,10 @@ contract LoopringProtocolImpl is LoopringProtocol {
         if (t == 0) {
             t = block.timestamp;
         }
+
+        (cutoffs[msg.sender] < t)
+            .orThrow("attempted to set cutoff to a smaller value");
+
         cutoffs[msg.sender] = t;
 
         CutoffTimestampChanged(
@@ -430,8 +440,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
         calculateRingFillAmount(ring);
 
         // Calculate each order's `lrcFee` and `lrcRewrard` and splict how much
-        // of `fillAmountS` shall be paid to matching order or miner as saving-
-        // share.
+        // of `fillAmountS` shall be paid to matching order or miner as margin
+        // split.
         calculateRingFees(ring);
 
         /// Make payments.
@@ -458,20 +468,20 @@ contract LoopringProtocolImpl is LoopringProtocol {
             var next = ring.orders[i.next(ringSize)];
 
             // Pay tokenS to previous order, or to miner as previous order's
-            // saving share or/and this order's saving share.
+            // margin split or/and this order's margin split.
 
             delegate.transferToken(
                 state.order.tokenS,
                 state.owner,
                 prev.owner,
-                state.fillAmountS - prev.savingB);
+                state.fillAmountS - prev.marginB);
 
-            if (prev.savingB + state.savingS > 0) {
+            if (prev.marginB + state.marginS > 0) {
                 delegate.transferToken(
                     state.order.tokenS,
                     state.owner,
                     ring.feeRecepient,
-                    prev.savingB + state.savingS);
+                    prev.marginB + state.marginS);
             }
 
             // Pay LRC
@@ -506,8 +516,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 prev.orderHash,
                 state.orderHash,
                 next.orderHash,
-                state.fillAmountS + state.savingS,
-                next.fillAmountS - state.savingB,
+                state.fillAmountS + state.marginS,
+                next.fillAmountS - state.marginB,
                 state.lrcReward,
                 state.lrcFee
                 );
@@ -558,39 +568,39 @@ contract LoopringProtocolImpl is LoopringProtocol {
                     minerLrcSpendable += lrcSpendable;
                 }
 
-            } else if (state.feeSelection == FEE_SELECT_SAVING_SHARE) {
+            } else if (state.feeSelection == FEE_SELECT_MARGIN_SPLIT) {
                 if (minerLrcSpendable >= state.lrcFee) {
                     if (state.order.buyNoMoreThanAmountB) {
-                        uint savingS = next.fillAmountS
+                        uint marginS = next.fillAmountS
                             .mul(state.order.amountS)
                             .div(state.order.amountB)
                             .sub(state.fillAmountS);
 
-                        state.savingS = savingS
-                            .mul(state.order.savingSharePercentage)
-                            .div(SAVING_SHARE_PERCENTAGE_BASE);
+                        state.marginS = marginS
+                            .mul(state.order.marginSplitPercentage)
+                            .div(MARGIN_SPLIT_PERCENTAGE_BASE);
                     } else {
-                        uint savingB = next.fillAmountS.sub(
+                        uint marginB = next.fillAmountS.sub(
                             state.fillAmountS
                                 .mul(state.order.amountB)
                                 .div(state.order.amountS));
 
-                        state.savingB = savingB
-                            .mul(state.order.savingSharePercentage)
-                            .div(SAVING_SHARE_PERCENTAGE_BASE);
+                        state.marginB = marginB
+                            .mul(state.order.marginSplitPercentage)
+                            .div(MARGIN_SPLIT_PERCENTAGE_BASE);
                     }
 
                     // This implicits order with smaller index in the ring will
                     // be paid LRC reward first, so the orders in the ring does
                     // mater.
-                    if (state.savingS > 0 || state.savingB > 0) {
+                    if (state.marginS > 0 || state.marginB > 0) {
                         minerLrcSpendable = minerLrcSpendable.sub(state.lrcFee);
                         state.lrcReward = state.lrcFee;
                     }
                     state.lrcFee = 0;
                 }
             } else {
-                ErrorLib.error("unsupported feeSelection value");
+                ErrorLib.error("unsupported fee selection value");
             }
         }
 
@@ -819,8 +829,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 0,   // fillAmountS
                 0,   // lrcReward
                 0,   // lrcFee
-                0,   // savingS
-                0    // savingB
+                0,   // marginS
+                0    // marginB
                 );
 
             /* (orders[i].availableAmountS > 0) */
@@ -847,13 +857,14 @@ contract LoopringProtocolImpl is LoopringProtocol {
             .orThrow("invalid order amountB");
         (order.timestamp > cutoffs[owner])
             .orThrow("order is cut off");
-        (order.expiration >= order.timestamp
-            && order.expiration >= block.timestamp)
-            .orThrow("invalid order expiration");
+        (order.ttl > 0)
+            .orThrow("order ttl is 0");
+        (order.timestamp + order.ttl > block.timestamp)
+            .orThrow("order is expired");
         (order.salt > 0)
             .orThrow("invalid order salt");
-        (order.savingSharePercentage <= SAVING_SHARE_PERCENTAGE_BASE)
-            .orThrow("invalid order savingSharePercentage");
+        (order.marginSplitPercentage <= MARGIN_SPLIT_PERCENTAGE_BASE)
+            .orThrow("invalid order marginSplitPercentage");
     }
 
     /// @dev Get the Keccak-256 hash of order with specified parameters.
@@ -869,11 +880,11 @@ contract LoopringProtocolImpl is LoopringProtocol {
             order.amountS,
             order.amountB,
             order.timestamp,
-            order.expiration,
+            order.ttl,
             order.salt,
             order.lrcFee,
             order.buyNoMoreThanAmountB,
-            order.savingSharePercentage);
+            order.marginSplitPercentage);
     }
 
     /// @return The signer's address.

--- a/test/testLoopringProtocolImpl.ts
+++ b/test/testLoopringProtocolImpl.ts
@@ -72,7 +72,7 @@ contract('LoopringProtocolImpl', (accounts: string[])=>{
       rand: 1234,
       lrcFee: new BigNumber(10),
       buyNoMoreThanAmountB: false,
-      savingSharePercentage: 0,
+      marginSplitPercentage: 0,
     };
 
     const orderPrams2 = {
@@ -86,7 +86,7 @@ contract('LoopringProtocolImpl', (accounts: string[])=>{
       rand: 4321,
       lrcFee: new BigNumber(10),
       buyNoMoreThanAmountB: false,
-      savingSharePercentage: 0,
+      marginSplitPercentage: 0,
     };
 
     order1 = new Order(order1Owner, orderPrams1);


### PR DESCRIPTION
also renamed 'saving share' to 'margin split' and
disabled setting address's cutoff to a smaller value.