### PR TITLE
Only calculate the split difference once instead of twice

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -514,12 +514,13 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 state.fillAmountS - prev.splitB
             );
 
-            if (prev.splitB + state.splitS > 0) {
+            var splitDiff = prev.splitB + state.splitS;
+            if (splitDiff > 0) {
                 delegate.transferToken(
                     state.order.tokenS,
                     state.order.owner,
                     ring.feeRecepient,
-                    prev.splitB + state.splitS
+                    splitDiff
                 );
             }
 

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -506,7 +506,6 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
             // Pay tokenS to previous order, or to miner as previous order's
             // margin split or/and this order's margin split.
-
             delegate.transferToken(
                 state.order.tokenS,
                 state.order.owner,
@@ -514,13 +513,13 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 state.fillAmountS - prev.splitB
             );
 
-            var splitDiff = prev.splitB + state.splitS;
-            if (splitDiff > 0) {
+            uint splitSum = prev.splitB + state.splitS;
+            if (splitSum > 0) {
                 delegate.transferToken(
                     state.order.tokenS,
                     state.order.owner,
                     ring.feeRecepient,
-                    splitDiff
+                    splitSum
                 );
             }
 


### PR DESCRIPTION
Move the split difference calculation in settleRing to before the conditional to prevent it from being calculated twice (once for the conditional and once for a value within the conditional).