### PR TITLE
Move variable declarations outside of conditionals.

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -612,8 +612,9 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
             } else if (state.feeSelection == FEE_SELECT_MARGIN_SPLIT) {
                 if (minerLrcSpendable >= state.lrcFee) {
+                    uint split;
                     if (state.order.buyNoMoreThanAmountB) {
-                        uint splitS = next.fillAmountS.mul(
+                        split = next.fillAmountS.mul(
                             state.order.amountS
                         ).div(
                             state.order.amountB
@@ -621,18 +622,18 @@ contract LoopringProtocolImpl is LoopringProtocol {
                             state.fillAmountS
                         );
 
-                        state.splitS = splitS.mul(
+                        state.splitS = split.mul(
                             state.order.marginSplitPercentage
                         ).div(
                             MARGIN_SPLIT_PERCENTAGE_BASE
                         );
                     } else {
-                        uint splitB = next.fillAmountS.sub(state.fillAmountS
+                        split = next.fillAmountS.sub(state.fillAmountS
                             .mul(state.order.amountB)
                             .div(state.order.amountS)
                         );
 
-                        state.splitB = splitB.mul(
+                        state.splitB = split.mul(
                             state.order.marginSplitPercentage
                         ).div(
                             MARGIN_SPLIT_PERCENTAGE_BASE
@@ -743,25 +744,26 @@ contract LoopringProtocolImpl is LoopringProtocol {
         for (uint i = 0; i < ringSize; i++) {
             var state = ring.orders[i];
             var order = state.order;
+            uint amount;
 
             if (order.buyNoMoreThanAmountB) {
-                uint amountB = order.amountB.tolerantSub(
+                amount = order.amountB.tolerantSub(
                     cancelledOrFilled[state.orderHash]
                 );
 
-                order.amountS = amountB.mul(order.amountS).div(order.amountB);
-                order.lrcFee = amountB.mul(order.lrcFee).div(order.amountB);
+                order.amountS = amount.mul(order.amountS).div(order.amountB);
+                order.lrcFee = amount.mul(order.lrcFee).div(order.amountB);
 
-                order.amountB = amountB;
+                order.amountB = amount;
             } else {
-                uint amountS = order.amountS.tolerantSub(
+                amount = order.amountS.tolerantSub(
                     cancelledOrFilled[state.orderHash]
                 );
 
-                order.amountB = amountS.mul(order.amountB).div(order.amountS);
-                order.lrcFee = amountS.mul(order.lrcFee).div(order.amountS);
+                order.amountB = amount.mul(order.amountB).div(order.amountS);
+                order.lrcFee = amount.mul(order.lrcFee).div(order.amountS);
 
-                order.amountS = amountS;
+                order.amountS = amount;
             }
 
             require(order.amountS > 0); // "amountS is zero");


### PR DESCRIPTION
Since all variables are scoped for an entire function, like javascript, whether a conditional hits or not the variable is declared and set to it's default value.
This means that in some places we could see unused variables being declared since that conditional branch never hit.
By declaring them before the conditional and using the same variable in each branch of the conditional we can cut down on the number of variables and thus gas usage.