### PR TITLE
WIP:fix lrc fee from partially filled order bug in simulator

### DIFF
--- a/util/protocol_simulator.ts
+++ b/util/protocol_simulator.ts
@@ -96,7 +96,6 @@ export class ProtocolSimulator {
         throw new Error("order amountS or amountB is zero");
       }
 
-      lrcFee = availableAmountB * lrcFee / amountB;
       order.params.scaledAmountS = availableAmountS;
       order.params.scaledAmountB =  availableAmountB;
       order.params.lrcFee = new BigNumber(lrcFee.toPrecision(15));
@@ -206,7 +205,7 @@ export class ProtocolSimulator {
       };
 
       if (0 == this.feeSelectionList[i]) {
-        feeItem.feeLrc = order.params.lrcFee.toNumber();
+        feeItem.feeLrc = order.params.lrcFee.toNumber() * fillAmountSList[i] / order.params.amountS.toNumber();
       } else if (1 == this.feeSelectionList[i]) {
         if (order.params.buyNoMoreThanAmountB) {
           feeItem.feeS = fillAmountSList[i] * order.params.scaledAmountS / rateAmountSList[i] - fillAmountSList[i];


### PR DESCRIPTION
In `protocol_simulator.ts` the lrc fee calculation is wrong for partially filled orders.
Sorry, this may not eligible for bug bounty