### PR TITLE
Cleaner batches, visiblity changes

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -520,7 +520,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         )
         private
         pure
-        returns (bytes32[] memory batch)
+        returns (bytes32[] batch)
     {
         uint batchSize = calculateTransferBatchSize(ringSize, orders);
         batch = new bytes32[](batchSize * 4); // ringSize * (token + from + to + value)

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -524,7 +524,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         )
         private
         pure
-        returns (bytes32[] batch)
+        returns (bytes32[] memory batch)
     {
         uint batchSize = calculateTransferBatchSize(ringSize, orders);
         batch = new bytes32[](batchSize * 4); // ringSize * (token + from + to + value)

--- a/contracts/RinghashRegistry.sol
+++ b/contracts/RinghashRegistry.sol
@@ -111,7 +111,7 @@ contract RinghashRegistry {
         bytes32[]   rList,
         bytes32[]   sList
         )
-        public
+        external
         view
         returns (bytes32 ringhash, bool[2] memory attributes)
     {

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -32,7 +32,7 @@ contract TokenRegistry is Ownable {
     mapping (string => address) tokenSymbolMap;
 
     function registerToken(address _token, string _symbol)
-        public
+        external
         onlyOwner
     {
         require(_token != address(0));
@@ -44,7 +44,7 @@ contract TokenRegistry is Ownable {
     }
 
     function unregisterToken(address _token, string _symbol)
-        public
+        external
         onlyOwner
     {
         require(tokenSymbolMap[_symbol] == _token);
@@ -61,7 +61,7 @@ contract TokenRegistry is Ownable {
 
     function isTokenRegisteredBySymbol(string symbol)
         public
-        constant
+        view
         returns (bool)
     {
         return tokenSymbolMap[symbol] != address(0);
@@ -69,7 +69,7 @@ contract TokenRegistry is Ownable {
 
     function isTokenRegistered(address _token)
         public
-        constant
+        view
         returns (bool)
     {
         return tokenMap[_token];
@@ -77,7 +77,7 @@ contract TokenRegistry is Ownable {
 
     function areAllTokensRegistered(address[] tokenList)
         public
-        constant
+        view
         returns (bool)
     {
         for (uint i = 0; i < tokenList.length; i++) {

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -168,15 +168,22 @@ contract TokenTransferDelegate is Ownable {
         onlyAuthorized
         external
     {
-        uint len = batch.length;
-        for (uint i = 0; i < len; i += 4) {
-            address from = address(batch[i + 1]);
-            address to = address(batch[i + 2]);
+        bytes32 from;
+        bytes32 to;
+        uint value;
+
+        for (uint i = 0; i < batch.length; i += 4) {
+            from = batch[i + 1];
+            to = batch[i + 2];
             if (from != to) {
-                uint value = uint(batch[i + 3]);
+                value = uint(batch[i + 3]);
                 if (value != 0) {
                     require(
-                        ERC20(address(batch[i])).transferFrom(from, to, value)
+                        ERC20(address(batch[i])).transferFrom(
+                            address(from),
+                            address(to),
+                            value
+                        )
                     );
                 }
             }

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -168,19 +168,17 @@ contract TokenTransferDelegate is Ownable {
         onlyAuthorized
         public
     {
-        for (uint i = 0; i < batch.length; i += 4) {
-            bytes32 from = batch[i + 1];
-            bytes32 to = batch[i + 2];
-            uint value = uint(batch[i + 3]);
-
-            if (value > 0 && from != to) {
-                require(
-                    ERC20(address(batch[i])).transferFrom(
-                        address(from),
-                        address(to),
-                        value
-                    )
-                );
+        uint len = batch.length;
+        for (uint i = 0; i < len; i += 4) {
+            address from = address(batch[i + 1]);
+            address to = address(batch[i + 2]);
+            if (from != to) {
+                uint value = uint(batch[i + 3]);
+                if (value != 0) {
+                    require(
+                        ERC20(address(batch[i])).transferFrom(from, to, value)
+                    );
+                }
             }
         }
     }

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -78,7 +78,7 @@ contract TokenTransferDelegate is Ownable {
     /// @param addr A loopring protocol address.
     function authorizeAddress(address addr)
         onlyOwner
-        public
+        external
     {
         AddressInfo storage addrInfo = addressInfos[addr];
 
@@ -107,7 +107,7 @@ contract TokenTransferDelegate is Ownable {
     /// @param addr A loopring protocol address.
     function deauthorizeAddress(address addr)
         onlyOwner
-        public
+        external
     {
         AddressInfo storage addrInfo = addressInfos[addr];
         if (addrInfo.index != 0) {
@@ -125,7 +125,7 @@ contract TokenTransferDelegate is Ownable {
     }
 
     function getLatestAuthorizedAddresses(uint max)
-        public
+        external
         view
         returns (address[] memory addresses)
     {
@@ -155,7 +155,7 @@ contract TokenTransferDelegate is Ownable {
         address to,
         uint    value)
         onlyAuthorized
-        public
+        external
     {
         if (value > 0 && from != to) {
             require(
@@ -166,7 +166,7 @@ contract TokenTransferDelegate is Ownable {
 
     function batchTransferToken(bytes32[] batch)
         onlyAuthorized
-        public
+        external
     {
         uint len = batch.length;
         for (uint i = 0; i < len; i += 4) {


### PR DESCRIPTION
 * Removed `fillTransferBatchItem` function.
 * Slightly optimized conditions around `batchTransferToken`.
 * Switched functions visibility to `private` and `external` where possible

Saves just a couple hundred gas.