### PR TITLE
Refactor TokenRegistry to use an iterable mapping

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -17,6 +17,7 @@
 */
 pragma solidity 0.4.18;
 
+import "./lib/AddressMap.sol";
 import "./lib/Ownable.sol";
 
 
@@ -24,48 +25,24 @@ import "./lib/Ownable.sol";
 /// @author Kongliang Zhong - <kongliang@loopring.org>,
 /// @author Daniel Wang - <daniel@loopring.org>.
 contract TokenRegistry is Ownable {
-
-    address[] public tokens;
-
-    mapping (address => bool) tokenMap;
-
-    mapping (string => address) tokenSymbolMap;
+    AddressMapping.AddressMap tokenMap;
 
     function registerToken(address _token, string _symbol)
         external
         onlyOwner
     {
         require(_token != address(0));
-        require(!isTokenRegisteredBySymbol(_symbol));
         require(!isTokenRegistered(_token));
-        tokens.push(_token);
-        tokenMap[_token] = true;
-        tokenSymbolMap[_symbol] = _token;
+        AddressMapping.insert(tokenMap, _token, keccak256(_symbol));
     }
 
-    function unregisterToken(address _token, string _symbol)
+    function unregisterToken(address _token)
         external
         onlyOwner
     {
         require(_token != address(0));
-        require(tokenSymbolMap[_symbol] == _token);
-        delete tokenSymbolMap[_symbol];
-        delete tokenMap[_token];
-        for (uint i = 0; i < tokens.length; i++) {
-            if (tokens[i] == _token) {
-                tokens[i] = tokens[tokens.length - 1];
-                tokens.length --;
-                break;
-            }
-        }
-    }
-
-    function isTokenRegisteredBySymbol(string symbol)
-        public
-        view
-        returns (bool)
-    {
-        return tokenSymbolMap[symbol] != address(0);
+        require(AddressMapping.contains(tokenMap, _token));
+        AddressMapping.remove(tokenMap, _token);
     }
 
     function isTokenRegistered(address _token)
@@ -73,7 +50,7 @@ contract TokenRegistry is Ownable {
         view
         returns (bool)
     {
-        return tokenMap[_token];
+        return AddressMapping.contains(tokenMap, _token);
     }
 
     function areAllTokensRegistered(address[] tokenList)
@@ -82,7 +59,7 @@ contract TokenRegistry is Ownable {
         returns (bool)
     {
         for (uint i = 0; i < tokenList.length; i++) {
-            if (!tokenMap[tokenList[i]]) {
+            if (!AddressMapping.contains(tokenMap, tokenList[i])) {
                 return false;
             }
         }
@@ -94,6 +71,15 @@ contract TokenRegistry is Ownable {
         constant
         returns (address)
     {
-        return tokenSymbolMap[symbol];
+        for (uint i = AddressMapping.iterateStart(tokenMap);
+            AddressMapping.iterateValid(tokenMap, i);
+            i = AddressMapping.iterateNext(tokenMap, i)
+        ) {
+            var (key, value) = AddressMapping.iterateGet(tokenMap, i);
+            if (keccak256(symbol) == value) {
+                return key;
+            }
+        }
+
     }
 }

--- a/contracts/lib/AddressMap.sol
+++ b/contracts/lib/AddressMap.sol
@@ -1,0 +1,87 @@
+pragma solidity 0.4.18;
+
+
+/// @dev iterable address mapping
+library AddressMapping {
+    struct AddressMap {
+        mapping(address => IndexValue) data;
+        KeyFlag[] keys;
+        uint size;
+    }
+    struct IndexValue { uint keyIndex; bytes32 value; }
+    struct KeyFlag { address key; bool deleted; }
+
+    function insert(AddressMap storage self, address key, bytes32 value)
+    internal
+    returns (bool replaced)
+    {
+        uint keyIndex = self.data[key].keyIndex;
+        self.data[key].value = value;
+        if (keyIndex > 0) {
+            return true;
+        } else {
+            keyIndex = self.keys.length++;
+            self.data[key].keyIndex = keyIndex + 1;
+            self.keys[keyIndex].key = key;
+            self.size++;
+            return false;
+        }
+    }
+
+    function remove(AddressMap storage self, address key)
+    internal
+    returns (bool success)
+    {
+        uint keyIndex = self.data[key].keyIndex;
+        if (keyIndex == 0)
+            return false;
+        delete self.data[key];
+        self.keys[keyIndex - 1].deleted = true;
+        self.size --;
+    }
+
+    function contains(AddressMap storage self, address key)
+    internal
+    view
+    returns (bool)
+    {
+        return self.data[key].keyIndex > 0;
+    }
+
+    function iterateStart(AddressMap storage self)
+    internal
+    view
+    returns (uint keyIndex)
+    {
+        return iterateNext(self, uint(-1));
+    }
+
+    function iterateValid(AddressMap storage self, uint keyIndex)
+    internal
+    view
+    returns (bool)
+    {
+        return keyIndex < self.keys.length;
+    }
+
+    function iterateNext(AddressMap storage self, uint keyIndex)
+    internal
+    view
+    returns (uint rkeyIndex)
+    {
+        keyIndex++;
+        while (keyIndex < self.keys.length && self.keys[keyIndex].deleted) {
+            keyIndex++;
+        }
+        return keyIndex;
+    }
+
+    function iterateGet(AddressMap storage self, uint keyIndex)
+    internal
+    view
+    returns (address key, bytes32 value)
+    {
+        key = self.keys[keyIndex].key;
+        value = self.data[key].value;
+    }
+}

--- a/test/testTokenRegistry.ts
+++ b/test/testTokenRegistry.ts
@@ -28,15 +28,11 @@ contract("TokenRegistry", (accounts: string[]) => {
 
     it("should be able to unregister a token", async () => {
       let isRegistered = await tokenRegistry.isTokenRegistered(testTokenAddr);
-      let isRegisteredBySymbol = await tokenRegistry.isTokenRegisteredBySymbol("TEST");
       assert.equal(isRegistered, true, "token should be registered on start");
-      assert.equal(isRegisteredBySymbol, true, "token should be registered on start");
 
-      await tokenRegistry.unregisterToken(testTokenAddr, "TEST", {from: owner});
+      await tokenRegistry.unregisterToken(testTokenAddr, {from: owner});
       isRegistered = await tokenRegistry.isTokenRegistered(testTokenAddr);
-      isRegisteredBySymbol = await tokenRegistry.isTokenRegisteredBySymbol("TEST");
       assert.equal(isRegistered, false, "token should be unregistered");
-      assert.equal(isRegisteredBySymbol, false, "token should be unregistered");
     });
 
   });


### PR DESCRIPTION
This makes a marginal saving in gas on my docker instance. But, the main benefit is the use of an iterable mapping for addresses.

If this is not wanted, feel free to decline this PR.