### PR TITLE
bug fix plus optimization for order fill

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -682,8 +682,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
         uint smallestIdx = 0;
         uint i;
         uint j;
-
-        for (i = 0; i < ringSize - 1; i++) {
+        uint lastIndex = ringSize - 1;
+        for (i = 0; i < lastIndex; i++) {
             j = i + 1;
             smallestIdx = calculateOrderFillAmount(
                 orders[i],
@@ -694,7 +694,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             );
         }
         calculateOrderFillAmount(
-            orders[ringSize - 1],
+            orders[lastIndex],
             orders[0]
         );
         for (i = 0; i < smallestIdx; i++) {

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -683,8 +683,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
         uint i;
         uint j;
 
-        for (i = 0; i < ringSize; i++) {
-            j = (i + 1) % ringSize;
+        for (i = 0; i < ringSize - 1; i++) {
+            j = i + 1;
             smallestIdx = calculateOrderFillAmount(
                 orders[i],
                 orders[j],
@@ -693,14 +693,14 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 smallestIdx
             );
         }
-
+        calculateOrderFillAmount(
+            orders[ringSize - 1],
+            orders[0]
+        );
         for (i = 0; i < smallestIdx; i++) {
             calculateOrderFillAmount(
                 orders[i],
-                orders[(i + 1) % ringSize],
-                0,               // Not needed
-                0,               // Not needed
-                0                // Not needed
+                orders[i + 1]
             );
         }
     }
@@ -747,6 +747,36 @@ contract LoopringProtocolImpl is LoopringProtocol {
         }
     }
 
+    /// @return The smallest order's index.
+    function calculateOrderFillAmount(
+        OrderState        state,
+        OrderState        next
+        )
+        private
+        pure
+    {
+        uint fillAmountB = state.fillAmountS.mul(
+            state.rate.amountB
+        ) / state.rate.amountS;
+
+        if (state.order.buyNoMoreThanAmountB) {
+            if (fillAmountB > state.order.amountB) {
+                fillAmountB = state.order.amountB;
+
+                state.fillAmountS = fillAmountB.mul(
+                    state.rate.amountS
+                ) / state.rate.amountB;
+            }
+        }
+
+        state.lrcFee = state.order.lrcFee.mul(
+            state.fillAmountS
+        ) / state.order.amountS;
+
+        if (fillAmountB <= next.fillAmountS) {
+            next.fillAmountS = fillAmountB;
+        } 
+    }
     /// @dev Scale down all orders based on historical fill or cancellation
     ///      stats but key the order's original exchange rate.
     function scaleRingBasedOnHistoricalRecords(


### PR DESCRIPTION
original code will fail when ring size is greater than 4 and `smallestIdx` is the last order index.
when the last order is the smallest order,  since the loop will over run by 1, then as `j = (i + 1) % ringSize;`, `j==0`, so  `smallestIdx`  will become to `0` too. Thus, second loop won't trigger. 

Since it alway over run by 1, this issue can't affect when `ringSize==3`, but will do affect when `ringSize > 3`

PS: it seems that currently we don't support ring size greater than 3