### PR TITLE
Possible optimization of RingMined event

### DIFF
--- a/contracts/LoopringProtocol.sol
+++ b/contracts/LoopringProtocol.sol
@@ -30,8 +30,7 @@ contract LoopringProtocol {
         uint                _ringIndex,
         bytes32     indexed _ringHash,
         address             _feeRecipient,
-        bytes32[]           _orderHashList,
-        uint[6][]           _amountsList
+        uint[]              _orderInfoList
     );
 
     event OrderCancelled(

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -398,9 +398,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         );
 
         /// Make transfers.
-        bytes32[] memory orderHashList;
-        uint[6][] memory amountsList;
-        (orderHashList, amountsList) = settleRing(
+        uint[] memory orderInfoList = settleRing(
             delegate,
             params.ringSize,
             orders,
@@ -412,8 +410,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             _ringIndex,
             params.ringHash,
             params.miner,
-            orderHashList,
-            amountsList
+            orderInfoList
         );
     }
 
@@ -425,13 +422,10 @@ contract LoopringProtocolImpl is LoopringProtocol {
         address       _lrcTokenAddress
         )
         private
-        returns (
-        bytes32[] memory orderHashList,
-        uint[6][] memory amountsList)
+        returns (uint[] memory orderInfoList)
     {
         bytes32[] memory batch = new bytes32[](ringSize * 7); // ringSize * (owner + tokenS + 4 amounts + wallet)
-        orderHashList = new bytes32[](ringSize);
-        amountsList = new uint[6][](ringSize);
+        orderInfoList = new uint[](ringSize * 6);
 
         uint p = 0;
         uint prevSplitB = orders[ringSize - 1].splitB;
@@ -458,15 +452,12 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 delegate.addCancelledOrFilled(state.orderHash, state.fillAmountS);
             }
 
-            orderHashList[i] = state.orderHash;
-
-            uint[6] memory amounts = amountsList[i];
-            amounts[0] = state.fillAmountS + state.splitS;
-            amounts[1] = nextFillAmountS - state.splitB;
-            amounts[2] = state.lrcReward;
-            amounts[3] = state.lrcFeeState;
-            amounts[4] = state.splitS;
-            amounts[5] = state.splitB;
+            orderInfoList[i*6 + 0] = uint(state.orderHash);
+            orderInfoList[i*6 + 1] = state.fillAmountS;
+            orderInfoList[i*6 + 2] = state.lrcReward;
+            orderInfoList[i*6 + 3] = state.lrcFeeState;
+            orderInfoList[i*6 + 4] = state.splitS;
+            orderInfoList[i*6 + 5] = state.splitB;
 
             prevSplitB = state.splitB;
         }


### PR DESCRIPTION
This saves about ~4000 gas. 

You may not like everything I did to do this. I minimized the data in the event like this:
- the data is sent in a way that still allows reconstructing the values, though some logic is needed
- lrcReward and lrcFee is packed in a single int called lrcBalance. lrcBalance will be positive when lrcReward is non-zero and negative when lrcFee is non-zero (lrcReward and lrcFee cannot be both non-zero).
- no separate array for the order hashes

lrcBalance is also used to send less data to batchTransferToken for some small extra gas savings.

lrcReward and lrcFee could also be stored as lrcBalance directly in the OrderState struct for some memory savings, though I'm not sure if that's a good idea for readability

Let me know if you're okay with any of these changes. I'm aware not all tests succeed because the interface of batchTransferToken has changed. If necessary I will of course update those tests.
