### PR TITLE
Optimization for 'sign orders with delegate's address implementation'

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -881,6 +881,11 @@ contract LoopringProtocolImpl is LoopringProtocol {
     {
         orders = new OrderState[](params.ringSize);
 
+
+        address[] memory owners = new address[](params.ringSize);
+        bytes20[] memory tradingPairs = new bytes20[](params.ringSize);
+        uint[] memory validSinceTimes = new uint[](params.ringSize);
+
         for (uint i = 0; i < params.ringSize; i++) {
 
             Order memory order = Order(
@@ -923,6 +928,10 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 0    // splitB
             );
 
+            owners[i] = order.owner;
+            tradingPairs[i] = bytes20(order.tokenS) ^ bytes20(order.tokenB);
+            validSinceTimes[i] = order.validSince;
+
             params.ringHash ^= orderHash;
         }
 
@@ -931,6 +940,9 @@ contract LoopringProtocolImpl is LoopringProtocol {
             params.minerId,
             params.feeSelections
         );
+
+        TokenTransferDelegate delegate = TokenTransferDelegate(delegateAddress);
+        delegate.checkCutoffsBatch(owners, tradingPairs, validSinceTimes);
     }
 
     /// @dev validate order's parameters are OK.
@@ -948,13 +960,13 @@ contract LoopringProtocolImpl is LoopringProtocol {
         require(order.validSince <= block.timestamp); // order is too early to match
         require(order.validUntil > block.timestamp); // order is expired
 
-        bytes20 tradingPair = bytes20(order.tokenS) ^ bytes20(order.tokenB);
-        TokenTransferDelegate delegate = TokenTransferDelegate(delegateAddress);
-        uint cutoff;
-        uint tradingPairCutoff;
-        (cutoff, tradingPairCutoff) = delegate.getCutoffAndTradingPairCutoff(order.owner, tradingPair);
-        require(order.validSince > tradingPairCutoff); // order trading pair is cut off
-        require(order.validSince > cutoff); // order is cut off
+        //bytes20 tradingPair = bytes20(order.tokenS) ^ bytes20(order.tokenB);
+        //TokenTransferDelegate delegate = TokenTransferDelegate(delegateAddress);
+        //uint cutoff;
+        //uint tradingPairCutoff;
+        //(cutoff, tradingPairCutoff) = delegate.getCutoffAndTradingPairCutoff(order.owner, tradingPair);
+        //require(order.validSince > tradingPairCutoff); // order trading pair is cut off
+        //require(order.validSince > cutoff); // order is cut off
     }
 
     /// @dev Get the Keccak-256 hash of order with specified parameters.

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -125,6 +125,21 @@ contract TokenTransferDelegate is Claimable {
         tradingPairCutoff = tradingPairCutoffs[owner][tradingPair];
     }
 
+    function checkCutoffsBatch(address[] owners, bytes20[] tradingPairs, uint[] validSince)
+        onlyAuthorized
+        external
+        view
+    {
+        uint len = owners.length;
+        require(len == tradingPairs.length);
+        require(len == validSince.length);
+
+        for(uint i = 0; i < len; i++) {
+            require(validSince[i] > tradingPairCutoffs[owners[i]][tradingPairs[i]]);  // order trading pair is cut off
+            require(validSince[i] > cutoffs[owners[i]]);                              // order is cut off
+        }
+    }
+
     function setCutoffs(uint t)
         onlyAuthorized
         external


### PR DESCRIPTION
Optizations for #297. Did not know where else to put this.

Saves about ~12500 gas on the 18000 gas increase.

Some thoughts about the optimizations (which all try to do the same thing: minimize delegate calls):
- checkCutoffsBatch() was introduced to batch check all order cutoffs. The bad thing about this is that validateOrder() doesn't do this check anymore. If this is not wanted there's an alternate optimization in comments that just requests cutoffs and tradingPairCutoffs together.
- addCancelledOrFilled is done in batchTransferToken(), which makes a lot of sense.
- cancelledOrFilledAmounts fetches are done in batches of 3. Solidity doesn't support returning dynamic arrays so this is done as a workaround. The code for this is pretty clean and simple so this doesn't add much complexity.

(batchTransferToken changed interface but I have not updated those specific tests yet. I will wait for feedback and update those tests when needed.)
 