### PR TITLE
Fixed TokenUnregistered event

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -29,7 +29,7 @@ contract TokenRegistry {
 
     event TokenUnregistered(
         address indexed addr,
-        string  indexed symbol
+        string          symbol
     );
 
     function registerToken(


### PR DESCRIPTION
'indexed' with strings is not possible (see [here](https://ethereum.stackexchange.com/a/7170) for more information). 'indexed' was probably unintentially added to the symbol variable.

This caused the 'TokenRegistry owner should be able to unregister a token' test to fail.