### PR TITLE
Optomisation: Encoded Inputs BuyNoMoreThanAmountB, FeeSelection and MarginSplitPercentage

### DIFF
--- a/contracts/LoopringProtocol.sol
+++ b/contracts/LoopringProtocol.sol
@@ -105,9 +105,10 @@ contract LoopringProtocol {
     ///                     validUntil (second), lrcFee, and rateAmountS.
     /// @param uint8ArgsList -
     ///                     List of unit8-type arguments, in this order:
-    ///                     marginSplitPercentageList.
-    /// @param buyNoMoreThanAmountBList -
-    ///                     This indicates when a order should be considered
+    ///                     marginSplitPercentageList. Bits 0-6 represent the marginSplitPercentage,
+    ///                     bits 7 represents the buyNoMoreThanAmountB as Boolean
+    ///                     bits 8 represents the feeSelection
+    ///                     also indicates when a order should be considered
     /// @param vList        List of v for each order. This list is 1-larger than
     ///                     the previous lists, with the last element being the
     ///                     v value of the ring signature.
@@ -118,19 +119,15 @@ contract LoopringProtocol {
     ///                     the previous lists, with the last element being the
     ///                     s value of the ring signature.
     /// @param miner        Miner address.
-    /// @param feeSelections -
-    ///                     Bits to indicate fee selections. `1` represents margin
-    ///                     split and `0` represents LRC as fee.
+
     function submitRing(
         address[4][]    addressList,
         uint[6][]       uintArgsList,
-        uint8[1][]      uint8ArgsList,
-        bool[]          buyNoMoreThanAmountBList,
+        uint16[]        uint8ArgsList,
         uint8[]         vList,
         bytes32[]       rList,
         bytes32[]       sList,
-        address         miner,
-        uint16          feeSelections
+        address         miner
         )
         public;
 }

--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -239,13 +239,11 @@ contract LoopringProtocolImpl is LoopringProtocol {
     function submitRing(
         address[4][]  addressList,
         uint[6][]     uintArgsList,
-        uint8[1][]    uint8ArgsList,
-        bool[]        buyNoMoreThanAmountBList,
+        uint16[]      uint8ArgsList,
         uint8[]       vList,
         bytes32[]     rList,
         bytes32[]     sList,
-        address       miner,
-        uint16        feeSelections
+        address       miner
         )
         public
     {
@@ -261,7 +259,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             rList,
             sList,
             miner,
-            feeSelections,
+            0,
             addressList.length,
             0x0 // ringHash
         );
@@ -270,8 +268,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             params,
             addressList,
             uintArgsList,
-            uint8ArgsList,
-            buyNoMoreThanAmountBList
+            uint8ArgsList
         );
 
 
@@ -284,8 +281,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
             delegate,
             addressList,
             uintArgsList,
-            uint8ArgsList,
-            buyNoMoreThanAmountBList
+            uint8ArgsList
         );
 
         verifyRingSignatures(params, orders);
@@ -767,8 +763,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         RingParams params,
         address[4][]  addressList,
         uint[6][]     uintArgsList,
-        uint8[1][]    uint8ArgsList,
-        bool[]        buyNoMoreThanAmountBList
+        uint16[]      uint8ArgsList
         )
         private
         pure
@@ -777,7 +772,6 @@ contract LoopringProtocolImpl is LoopringProtocol {
         require(params.ringSize == addressList.length);
         require(params.ringSize == uintArgsList.length);
         require(params.ringSize == uint8ArgsList.length);
-        require(params.ringSize == buyNoMoreThanAmountBList.length);
 
         // Validate ring-mining related arguments.
         for (uint i = 0; i < params.ringSize; i++) {
@@ -800,8 +794,7 @@ contract LoopringProtocolImpl is LoopringProtocol {
         TokenTransferDelegate delegate,
         address[4][]  addressList,
         uint[6][]     uintArgsList,
-        uint8[1][]    uint8ArgsList,
-        bool[]        buyNoMoreThanAmountBList
+        uint16[]      uint8ArgsList
         )
         private
         view
@@ -811,7 +804,17 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
         for (uint i = 0; i < params.ringSize; i++) {
             uint[6] memory uintArgs = uintArgsList[i];
-            bool marginSplitAsFee = (params.feeSelections & (uint16(1) << i)) > 0;
+
+            //decode input variables
+            bool marginSplitAsFee = (uint8ArgsList[i] & (uint16(1) << 8)) > 0;
+            bool buyNoMoreThanAmountB = (uint8ArgsList[i] & (uint16(1) << 7)) > 0;
+            uint16 marginSplitPercentage;
+            if (buyNoMoreThanAmountB) {
+                marginSplitPercentage = uint8ArgsList[i] ^ (uint16(1)) << 7;
+            } else {
+                marginSplitPercentage = uint8ArgsList[i];
+            }
+
             orders[i] = OrderState(
                 addressList[i][0],
                 addressList[i][1],
@@ -823,10 +826,10 @@ contract LoopringProtocolImpl is LoopringProtocol {
                 uintArgs[0],
                 uintArgs[1],
                 uintArgs[4],
-                buyNoMoreThanAmountBList[i],
+                buyNoMoreThanAmountB,
                 marginSplitAsFee,
                 bytes32(0),
-                uint8ArgsList[i][0],
+                uint8(marginSplitPercentage),
                 uintArgs[5],
                 uintArgs[1],
                 0,   // fillAmountS
@@ -838,18 +841,20 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
             validateOrder(orders[i]);
 
-            bytes32 orderHash = calculateOrderHash(orders[i]);
-            orders[i].orderHash = orderHash;
+            orders[i].orderHash = calculateOrderHash(orders[i]);
 
             verifySignature(
                 orders[i].owner,
-                orderHash,
+                orders[i].orderHash,
                 params.vList[i],
                 params.rList[i],
                 params.sList[i]
             );
 
-            params.ringHash ^= orderHash;
+            params.ringHash ^= orders[i].orderHash;
+            if(marginSplitAsFee){
+                params.feeSelections += uint16(1) << i;
+            }
         }
 
         validateOrdersCutoffs(orders, delegate);

--- a/test/testLoopringProtocolImpl.ts
+++ b/test/testLoopringProtocolImpl.ts
@@ -150,12 +150,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -203,12 +201,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
 
@@ -253,12 +249,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       console.log("cumulativeGasUsed for a ring of 2 orders: " + tx.receipt.gasUsed);
@@ -313,12 +307,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       console.log("cumulativeGasUsed for a ring of 3 orders: " + tx.receipt.gasUsed);
@@ -384,12 +376,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -459,12 +449,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -527,12 +515,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -605,12 +591,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -672,12 +656,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
       const tx = await loopringProtocolImpl.submitRing(p.addressList,
                                                        p.uintArgsList,
                                                        p.uint8ArgsList,
-                                                       p.buyNoMoreThanAmountBList,
                                                        p.vList,
                                                        p.rList,
                                                        p.sList,
                                                        p.feeRecepient,
-                                                       p.feeSelections,
                                                        {from: owner});
 
       // console.log("tx.receipt.logs: ", tx.receipt.logs);
@@ -775,12 +757,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
         await loopringProtocolImpl.submitRing(p.addressList,
                                               p.uintArgsList,
                                               p.uint8ArgsList,
-                                              p.buyNoMoreThanAmountBList,
                                               p.vList,
                                               p.rList,
                                               p.sList,
                                               p.feeRecepient,
-                                              p.feeSelections,
                                               {from: owner});
       } catch (err) {
         const errMsg = `${err}`;
@@ -815,12 +795,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
         await loopringProtocolImpl.submitRing(p.addressList,
                                               p.uintArgsList,
                                               p.uint8ArgsList,
-                                              p.buyNoMoreThanAmountBList,
                                               p.vList,
                                               p.rList,
                                               p.sList,
                                               p.feeRecepient,
-                                              p.feeSelections,
                                               {from: owner});
       } catch (err) {
         const errMsg = `${err}`;
@@ -940,12 +918,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
         await loopringProtocolImpl.submitRing(p.addressList,
                                               p.uintArgsList,
                                               p.uint8ArgsList,
-                                              p.buyNoMoreThanAmountBList,
                                               p.vList,
                                               p.rList,
                                               p.sList,
                                               p.feeRecepient,
-                                              p.feeSelections,
                                               {from: owner});
       } catch (err) {
         const errMsg = `${err}`;
@@ -995,12 +971,10 @@ contract("LoopringProtocolImpl", (accounts: string[]) => {
         await loopringProtocolImpl.submitRing(p.addressList,
                                               p.uintArgsList,
                                               p.uint8ArgsList,
-                                              p.buyNoMoreThanAmountBList,
                                               p.vList,
                                               p.rList,
                                               p.sList,
                                               p.feeRecepient,
-                                              p.feeSelections,
                                               {from: owner});
       } catch (err) {
         const errMsg = `${err}`;

--- a/util/ring_factory.ts
+++ b/util/ring_factory.ts
@@ -428,8 +428,7 @@ export class RingFactory {
     const ringSize = ring.orders.length;
     const addressList: string[][] = [];
     const uintArgsList: BigNumber[][] = [];
-    const uint8ArgsList: number[][] = [];
-    const buyNoMoreThanAmountBList: boolean[] = [];
+    const uint8ArgsList: number[] = [];
     const vList: number[] = [];
     const rList: string[] = [];
     const sList: string[] = [];
@@ -456,12 +455,14 @@ export class RingFactory {
       ];
       uintArgsList.push(uintArgsListItem);
 
-      const uint8ArgsListItem = [order.params.marginSplitPercentage];
+      const encoded = this.BuyNoMoreAndMarginEncode(order.params.buyNoMoreThanAmountB,
+        order.params.marginSplitPercentage,
+        feeSelectionList[i]);
+
+      // const uint8ArgsListItem = [encoded];
       // console.log("uint8ArgsListItem", uint8ArgsListItem);
 
-      uint8ArgsList.push(uint8ArgsListItem);
-
-      buyNoMoreThanAmountBList.push(order.params.buyNoMoreThanAmountB);
+      uint8ArgsList.push(encoded);
 
       vList.push(order.params.v);
       rList.push(order.params.r);
@@ -480,13 +481,11 @@ export class RingFactory {
       addressList,
       uintArgsList,
       uint8ArgsList,
-      buyNoMoreThanAmountBList,
       vList,
       rList,
       sList,
       ringOwner: ring.owner,
       feeRecepient,
-      feeSelections: this.feeSelectionListToNumber(feeSelectionList),
     };
 
     return submitParams;
@@ -498,6 +497,19 @@ export class RingFactory {
       res += feeSelections[i] << i;
     }
 
+    return res;
+  }
+
+  public BuyNoMoreAndMarginEncode(buyNoMoreThanAmountB: boolean, marginSplitPercentage: number, feeSelection: number) {
+    let res = marginSplitPercentage;
+    let buy = 0;
+    if (buyNoMoreThanAmountB) {
+      buy = 1;
+    }
+
+    res += buy << 7;
+
+    res += feeSelection << 8;
     return res;
   }
 

--- a/util/types.ts
+++ b/util/types.ts
@@ -27,14 +27,12 @@ export interface OrderParams {
 export interface LoopringSubmitParams {
   addressList: string[][];
   uintArgsList: BigNumber[][];
-  uint8ArgsList: number[][];
-  buyNoMoreThanAmountBList: boolean[];
+  uint8ArgsList: number[];
   vList: number[];
   rList: string[];
   sList: string[];
   ringOwner: string;
   feeRecepient: string;
-  feeSelections: number;
 }
 
 export interface FeeItem {


### PR DESCRIPTION
**Gas Reduction:** ~1000

**Tests:** Updated and Working _(except the one that was broken related to tokencreator see #310 )_

**Related Issues:** #135 - Several months ago Daniel asked me to try and get that #135 implemented, at the time I couldn't figure out a great way of doing it. However I finally cracked it and it has a small gas saving.

**Notes:**
This replaces three inputs (buynomorethanblist, uint8argslist and feeselections) with a single encoded variable that is decoded at contract runtime. The encoding is required when the order is being constructed, it is relatively simple - see "buyNoMoreAndMarginEncode" in ring_factory.ts for further detail on how I implemented the encoder. 

There is scope to take this further and save a little more gas by encapsulating the encoded uint8argslist into a single uint256. I will be exploring this later on today to see if that is worthwhile.

in addition to the encoding I removed the second array related to uint8argslist for extra savings. Referencing uint8argslist as many times as I have to with the new changes, removes all gas savings when it is structured as a uint8[1][]. Finally I had to change to a uint16[] in order to make it all work.

**The encoding is done as such:**
First 7 bits represent the marginSplitPercentage,
8th bit represents the buyNoMoreThanAmountB
9th bit represents the feeSelection