### PR TITLE
Optimized bytesToBytes32

### DIFF
--- a/contracts/lib/BytesUtil.sol
+++ b/contracts/lib/BytesUtil.sol
@@ -30,8 +30,11 @@ library BytesUtil {
         pure
         returns (bytes32 out)
     {
-        for (uint i = 0; i < 32; i++) {
-            out |= bytes32(b[offset + i] & 0xFF) >> (i * 8);
+        require(b.length >= offset + 32);
+        bytes32 temp;
+        assembly {
+            temp := mload(add(add(b, 0x20), offset))
         }
+        return temp;
     }
 }


### PR DESCRIPTION
Optimization for #320.

Should significantly reduce gas cost by about ~7500 for every call (and there are quite a lot of calls to this function: 4 * ringSize calls to this function in submitRing). 

It seems like the tests haven't been updated yet for all API changes in 1.6 so I cannot be sure how much gas is saved. But I tested the function externally and it should work fine.