### PR TITLE
Fixed 'Optimized TokenTransferDelegate calls'

### DIFF
--- a/contracts/LoopringProtocolImpl.sol
+++ b/contracts/LoopringProtocolImpl.sol
@@ -424,13 +424,11 @@ contract LoopringProtocolImpl is LoopringProtocol {
         private
         returns (bytes32[] memory orderInfoList)
     {
-        bytes32[] memory batch = new bytes32[](ringSize * 7); // ringSize * (owner + tokenS + 4 amounts + wallet)
-        bytes32[] memory historyBatch = new bytes32[](ringSize * 2); // ringSize * (orderhash, fillAmount)
+        bytes32[] memory batch = new bytes32[](ringSize * 9); // ringSize * (owner + tokenS + 4 amounts + wallet + orderhash + fillAmount)
         orderInfoList = new bytes32[](ringSize * 7);
 
         uint p = 0;
         uint q = 0;
-        uint r = 0;
         uint prevSplitB = orders[ringSize - 1].splitB;
         for (uint i = 0; i < ringSize; i++) {
             OrderState memory state = orders[i];
@@ -447,8 +445,8 @@ contract LoopringProtocolImpl is LoopringProtocol {
             batch[p++] = bytes32(state.lrcFeeState);
             batch[p++] = bytes32(state.wallet);
 
-            historyBatch[r++] = state.orderHash;
-            historyBatch[r++] = bytes32(
+            batch[p++] = state.orderHash;
+            batch[p++] = bytes32(
                 state.buyNoMoreThanAmountB ? nextFillAmountS : state.fillAmountS);
 
             orderInfoList[q++] = bytes32(state.orderHash);
@@ -465,11 +463,9 @@ contract LoopringProtocolImpl is LoopringProtocol {
 
             prevSplitB = state.splitB;
         }
-        // Update fill records
-        delegate.batchAddCancelledOrFilled(historyBatch);
 
         // Do all transactions
-        delegate.batchTransferToken(
+        delegate.batchUpdateHistoryAndTransferTokens(
             _lrcTokenAddress,
             tx.origin,
             feeRecipient,
@@ -714,23 +710,28 @@ contract LoopringProtocolImpl is LoopringProtocol {
         private
         view
     {
+        uint[3] memory cancelledOrFilledAmounts;
         for (uint i = 0; i < ringSize; i++) {
             OrderState memory state = orders[i];
             uint amount;
 
-            if (state.buyNoMoreThanAmountB) {
-                amount = state.amountB.tolerantSub(
-                    delegate.cancelledOrFilled(state.orderHash)
+            if(i % 3 == 0) {
+                cancelledOrFilledAmounts = delegate.getCancelledOrFilledBatch(
+                    state.orderHash,
+                    (i+1 < ringSize) ? orders[i+1].orderHash : bytes32(0),
+                    (i+2 < ringSize) ? orders[i+2].orderHash : bytes32(0)
                 );
+            }
+
+            if (state.buyNoMoreThanAmountB) {
+                amount = state.amountB.tolerantSub(cancelledOrFilledAmounts[i % 3]);
 
                 state.amountS = amount.mul(state.amountS) / state.amountB;
                 state.lrcFee = amount.mul(state.lrcFee) / state.amountB;
 
                 state.amountB = amount;
             } else {
-                amount = state.amountS.tolerantSub(
-                    delegate.cancelledOrFilled(state.orderHash)
-                );
+                amount = state.amountS.tolerantSub(cancelledOrFilledAmounts[i % 3]);
 
                 state.amountB = amount.mul(state.amountB) / state.amountS;
                 state.lrcFee = amount.mul(state.lrcFee) / state.amountS;

--- a/contracts/TokenTransferDelegate.sol
+++ b/contracts/TokenTransferDelegate.sol
@@ -79,7 +79,7 @@ contract TokenTransferDelegate {
         )
         external;
 
-    function batchTransferToken(
+    function batchUpdateHistoryAndTransferTokens(
         address lrcTokenAddress,
         address miner,
         address minerFeeRecipient,
@@ -101,8 +101,10 @@ contract TokenTransferDelegate {
     function addCancelledOrFilled(bytes32 orderHash, uint cancelOrFillAmount)
         public;
 
-    function batchAddCancelledOrFilled(bytes32[] batch)
-        public;
+    function getCancelledOrFilledBatch(bytes32 orderHashA, bytes32 orderHashB, bytes32 orderHashC)
+        external
+        view
+        returns (uint[3] amounts);
 
     function setCutoffs(uint t)
         external;

--- a/test/testTokenTransferDelegate.ts
+++ b/test/testTokenTransferDelegate.ts
@@ -132,6 +132,8 @@ contract("TokenTransferDelegate", (accounts: string[]) => {
       batch.push(numberToBytes32Str(0));
       batch.push(numberToBytes32Str(5e18));
       batch.push(walletAddr1);
+      batch.push(numberToBytes32Str(0));
+      batch.push(numberToBytes32Str(0));
 
       batch.push(addressToBytes32Str(trader2));
       batch.push(addressToBytes32Str(neoAddress));
@@ -140,9 +142,12 @@ contract("TokenTransferDelegate", (accounts: string[]) => {
       batch.push(numberToBytes32Str(0));
       batch.push(numberToBytes32Str(5e18));
       batch.push(walletAddr2);
+      batch.push(numberToBytes32Str(0));
+      batch.push(numberToBytes32Str(0));
 
-      const tx = await tokenTransferDelegate.batchTransferToken(lrcAddress, loopringProtocolV1, owner, 20, batch,
-                                                                {from: loopringProtocolV1});
+      const tx = await tokenTransferDelegate.batchUpdateHistoryAndTransferTokens(
+          lrcAddress, loopringProtocolV1, owner, 20, batch,
+          {from: loopringProtocolV1});
 
       const trader1NeoBalance = await getTokenBalanceAsync(neo, trader1);
       const trader2EosBalance = await getTokenBalanceAsync(eos, trader2);
@@ -179,6 +184,8 @@ contract("TokenTransferDelegate", (accounts: string[]) => {
         batch.push(numberToBytes32Str(0));
         batch.push(numberToBytes32Str(5e18));
         batch.push(walletAddr1);
+        batch.push(numberToBytes32Str(0));
+        batch.push(numberToBytes32Str(0));
 
         batch.push(addressToBytes32Str(trader2));
         batch.push(addressToBytes32Str(neoAddress));
@@ -187,9 +194,12 @@ contract("TokenTransferDelegate", (accounts: string[]) => {
         batch.push(numberToBytes32Str(0));
         batch.push(numberToBytes32Str(5e18));
         batch.push(walletAddr2);
+        batch.push(numberToBytes32Str(0));
+        batch.push(numberToBytes32Str(0));
 
-        const tx = await tokenTransferDelegate.batchTransferToken(lrcAddress, loopringProtocolV2, owner, 20, batch,
-                                                                  {from: loopringProtocolV2});
+        const tx = await tokenTransferDelegate.batchUpdateHistoryAndTransferTokens(
+            lrcAddress, loopringProtocolV2, owner, 20, batch,
+            {from: loopringProtocolV2});
       } catch (err) {
         const errMsg = `${err}`;
         assert(_.includes(errMsg, "Error: VM Exception while processing transaction: revert"),


### PR DESCRIPTION
This is an update of PR #309 for the latest master.

Because of some changes to the master gas savings should now be ~6000 (470.000 -> 464.000).

Additionaly I renamed batchTransferToken to batchUpdateHistoryAndTransferTokens as proposed by Daniel in #323.